### PR TITLE
Tempo settings

### DIFF
--- a/src/helpers/analyze.ts
+++ b/src/helpers/analyze.ts
@@ -1,7 +1,7 @@
 import { computeTempoBuckets } from './compute-tempo-buckets';
 
-export const analyze = (channelData: Float32Array, sampleRate: number) => {
-    const tempoBuckets = computeTempoBuckets(channelData, sampleRate);
+export const analyze = (channelData: Float32Array, sampleRate: number, minTempo = 90, maxTempo = 180) => {
+    const tempoBuckets = computeTempoBuckets(channelData, sampleRate, minTempo, maxTempo);
 
     if (tempoBuckets.length === 0) {
         throw new Error('The given channelData does not contain any detectable beats.');

--- a/src/helpers/analyze.ts
+++ b/src/helpers/analyze.ts
@@ -1,7 +1,8 @@
+import { ITempoSettings } from '../interfaces';
 import { computeTempoBuckets } from './compute-tempo-buckets';
 
-export const analyze = (channelData: Float32Array, sampleRate: number, minTempo = 90, maxTempo = 180) => {
-    const tempoBuckets = computeTempoBuckets(channelData, sampleRate, minTempo, maxTempo);
+export const analyze = (channelData: Float32Array, sampleRate: number, tempoSettings?: ITempoSettings) => {
+    const tempoBuckets = computeTempoBuckets(channelData, sampleRate, tempoSettings);
 
     if (tempoBuckets.length === 0) {
         throw new Error('The given channelData does not contain any detectable beats.');

--- a/src/helpers/compute-tempo-buckets.ts
+++ b/src/helpers/compute-tempo-buckets.ts
@@ -6,7 +6,7 @@ import { groupNeighborsByTempo } from './group-neighbors-by-tempo';
 
 const MINUMUM_NUMBER_OF_PEAKS = 30;
 
-export const computeTempoBuckets = (channelData: Float32Array, sampleRate: number): ITempoBucket[] => {
+export const computeTempoBuckets = (channelData: Float32Array, sampleRate: number, minTempo = 90, maxTempo = 180): ITempoBucket[] => {
     const maximumValue = getMaximumValue(channelData);
     const minimumThreshold = maximumValue * 0.3;
 
@@ -21,7 +21,7 @@ export const computeTempoBuckets = (channelData: Float32Array, sampleRate: numbe
     }
 
     const intervalBuckets = countIntervalsBetweenNearbyPeaks(peaks);
-    const tempoBuckets = groupNeighborsByTempo(intervalBuckets, sampleRate);
+    const tempoBuckets = groupNeighborsByTempo(intervalBuckets, sampleRate, minTempo, maxTempo);
 
     tempoBuckets.sort((a, b) => b.score - a.score);
 

--- a/src/helpers/compute-tempo-buckets.ts
+++ b/src/helpers/compute-tempo-buckets.ts
@@ -1,4 +1,4 @@
-import { ITempoBucket } from '../interfaces';
+import { ITempoBucket, ITempoSettings } from '../interfaces';
 import { countIntervalsBetweenNearbyPeaks } from './count-intervals-between-nearby-peaks';
 import { getMaximumValue } from './get-maximum-value';
 import { getPeaksAtThreshold } from './get-peaks-at-threshold';
@@ -6,7 +6,7 @@ import { groupNeighborsByTempo } from './group-neighbors-by-tempo';
 
 const MINUMUM_NUMBER_OF_PEAKS = 30;
 
-export const computeTempoBuckets = (channelData: Float32Array, sampleRate: number, minTempo = 90, maxTempo = 180): ITempoBucket[] => {
+export const computeTempoBuckets = (channelData: Float32Array, sampleRate: number, tempoSettings?: ITempoSettings): ITempoBucket[] => {
     const maximumValue = getMaximumValue(channelData);
     const minimumThreshold = maximumValue * 0.3;
 
@@ -21,7 +21,7 @@ export const computeTempoBuckets = (channelData: Float32Array, sampleRate: numbe
     }
 
     const intervalBuckets = countIntervalsBetweenNearbyPeaks(peaks);
-    const tempoBuckets = groupNeighborsByTempo(intervalBuckets, sampleRate, minTempo, maxTempo);
+    const tempoBuckets = groupNeighborsByTempo(intervalBuckets, sampleRate, tempoSettings);
 
     tempoBuckets.sort((a, b) => b.score - a.score);
 

--- a/src/helpers/group-neighbors-by-tempo.ts
+++ b/src/helpers/group-neighbors-by-tempo.ts
@@ -1,17 +1,17 @@
 import { IIntervalBucket, ITempoBucket } from '../interfaces';
 
-export const groupNeighborsByTempo = (intervalBuckets: IIntervalBucket[], sampleRate: number) => {
+export const groupNeighborsByTempo = (intervalBuckets: IIntervalBucket[], sampleRate: number, minTempo = 90, maxTempo = 180) => {
     const tempoBuckets: ITempoBucket[] = [];
 
     intervalBuckets.forEach((intervalBucket) => {
         // Convert an interval to a tempo (aka BPM).
         let theoreticalTempo = 60 / (intervalBucket.interval / sampleRate);
 
-        // Adjust the tempo to fit within the 90-180 BPM range.
-        while (theoreticalTempo < 90) {
+        // Adjust the tempo to fit within the min-max (90-180) BPM range.
+        while (theoreticalTempo < minTempo) {
             theoreticalTempo *= 2;
         }
-        while (theoreticalTempo > 180) {
+        while (theoreticalTempo > maxTempo) {
             theoreticalTempo /= 2;
         }
 

--- a/src/helpers/group-neighbors-by-tempo.ts
+++ b/src/helpers/group-neighbors-by-tempo.ts
@@ -1,7 +1,9 @@
-import { IIntervalBucket, ITempoBucket } from '../interfaces';
+import { IIntervalBucket, ITempoBucket, ITempoSettings } from '../interfaces';
 
-export const groupNeighborsByTempo = (intervalBuckets: IIntervalBucket[], sampleRate: number, minTempo = 90, maxTempo = 180) => {
+export const groupNeighborsByTempo = (intervalBuckets: IIntervalBucket[], sampleRate: number, tempoSettings: ITempoSettings = {}) => {
     const tempoBuckets: ITempoBucket[] = [];
+    const minTempo = typeof tempoSettings.minTempo === 'number' ? tempoSettings.minTempo : 90;
+    const maxTempo = typeof tempoSettings.maxTempo === 'number' ? tempoSettings.maxTempo : 180;
 
     intervalBuckets.forEach((intervalBucket) => {
         // Convert an interval to a tempo (aka BPM).

--- a/src/helpers/guess.ts
+++ b/src/helpers/guess.ts
@@ -1,7 +1,7 @@
 import { computeTempoBuckets } from './compute-tempo-buckets';
 
-export const guess = (channelData: Float32Array, sampleRate: number) => {
-    const tempoBuckets = computeTempoBuckets(channelData, sampleRate);
+export const guess = (channelData: Float32Array, sampleRate: number, minTempo = 90, maxTempo = 180) => {
+    const tempoBuckets = computeTempoBuckets(channelData, sampleRate, minTempo, maxTempo);
 
     if (tempoBuckets.length === 0) {
         throw new Error('The given channelData does not contain any detectable beats.');

--- a/src/helpers/guess.ts
+++ b/src/helpers/guess.ts
@@ -1,7 +1,8 @@
+import { ITempoSettings } from '../interfaces';
 import { computeTempoBuckets } from './compute-tempo-buckets';
 
-export const guess = (channelData: Float32Array, sampleRate: number, minTempo = 90, maxTempo = 180) => {
-    const tempoBuckets = computeTempoBuckets(channelData, sampleRate, minTempo, maxTempo);
+export const guess = (channelData: Float32Array, sampleRate: number, tempoSettings?: ITempoSettings) => {
+    const tempoBuckets = computeTempoBuckets(channelData, sampleRate, tempoSettings);
 
     if (tempoBuckets.length === 0) {
         throw new Error('The given channelData does not contain any detectable beats.');

--- a/src/interfaces/analyze-request.ts
+++ b/src/interfaces/analyze-request.ts
@@ -6,6 +6,10 @@ export interface IAnalyzeRequest {
     params: {
         channelData: Float32Array;
 
+        maxTempo?: number;
+
+        minTempo?: number;
+
         sampleRate: number;
     };
 }

--- a/src/interfaces/analyze-request.ts
+++ b/src/interfaces/analyze-request.ts
@@ -1,3 +1,5 @@
+import { ITempoSettings } from './tempo-settings';
+
 export interface IAnalyzeRequest {
     id: number;
 
@@ -6,10 +8,8 @@ export interface IAnalyzeRequest {
     params: {
         channelData: Float32Array;
 
-        maxTempo?: number;
-
-        minTempo?: number;
-
         sampleRate: number;
+
+        tempoSettings?: ITempoSettings;
     };
 }

--- a/src/interfaces/guess-request.ts
+++ b/src/interfaces/guess-request.ts
@@ -1,3 +1,5 @@
+import { ITempoSettings } from './tempo-settings';
+
 export interface IGuessRequest {
     id: number;
 
@@ -6,10 +8,8 @@ export interface IGuessRequest {
     params: {
         channelData: Float32Array;
 
-        maxTempo?: number;
-
-        minTempo?: number;
-
         sampleRate: number;
+
+        tempoSettings?: ITempoSettings;
     };
 }

--- a/src/interfaces/guess-request.ts
+++ b/src/interfaces/guess-request.ts
@@ -6,6 +6,10 @@ export interface IGuessRequest {
     params: {
         channelData: Float32Array;
 
+        maxTempo?: number;
+
+        minTempo?: number;
+
         sampleRate: number;
     };
 }

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -6,4 +6,5 @@ export * from './guess-response';
 export * from './error-response';
 export * from './interval-bucket';
 export * from './tempo-bucket';
+export * from './tempo-settings';
 export * from './worker-event';

--- a/src/interfaces/tempo-settings.ts
+++ b/src/interfaces/tempo-settings.ts
@@ -1,0 +1,5 @@
+export interface ITempoSettings {
+    maxTempo?: number;
+
+    minTempo?: number;
+}

--- a/src/module.ts
+++ b/src/module.ts
@@ -14,10 +14,10 @@ addEventListener('message', ({ data }: IBrokerEvent) => {
         if (data.method === 'analyze') {
             const {
                 id,
-                params: { channelData, sampleRate, minTempo, maxTempo }
+                params: { channelData, sampleRate, tempoSettings }
             } = data;
 
-            const tempo = analyze(channelData, sampleRate, minTempo, maxTempo);
+            const tempo = analyze(channelData, sampleRate, tempoSettings);
 
             postMessage(<IAnalyzeResponse>{
                 error: null,
@@ -27,10 +27,10 @@ addEventListener('message', ({ data }: IBrokerEvent) => {
         } else if (data.method === 'guess') {
             const {
                 id,
-                params: { channelData, sampleRate, minTempo, maxTempo }
+                params: { channelData, sampleRate, tempoSettings }
             } = data;
 
-            const { bpm, offset } = guess(channelData, sampleRate, minTempo, maxTempo);
+            const { bpm, offset } = guess(channelData, sampleRate, tempoSettings);
 
             postMessage(<IGuessResponse>{
                 error: null,

--- a/src/module.ts
+++ b/src/module.ts
@@ -14,10 +14,10 @@ addEventListener('message', ({ data }: IBrokerEvent) => {
         if (data.method === 'analyze') {
             const {
                 id,
-                params: { channelData, sampleRate }
+                params: { channelData, sampleRate, minTempo, maxTempo }
             } = data;
 
-            const tempo = analyze(channelData, sampleRate);
+            const tempo = analyze(channelData, sampleRate, minTempo, maxTempo);
 
             postMessage(<IAnalyzeResponse>{
                 error: null,
@@ -27,10 +27,10 @@ addEventListener('message', ({ data }: IBrokerEvent) => {
         } else if (data.method === 'guess') {
             const {
                 id,
-                params: { channelData, sampleRate }
+                params: { channelData, sampleRate, minTempo, maxTempo }
             } = data;
 
-            const { bpm, offset } = guess(channelData, sampleRate);
+            const { bpm, offset } = guess(channelData, sampleRate, minTempo, maxTempo);
 
             postMessage(<IGuessResponse>{
                 error: null,


### PR DESCRIPTION
Hey @chrisguttandin !

Feel free to close this out (as I don't need the feature), but on the web-audio slack yesterday I saw someone ask a question about BPM detection.  That person uploaded a sample that they expected to be "80" bpm.

This lib was detecting around 106 bpm, but when I modified the "target" bpm values, it started detecting 80.

I'm not familiar w/ the code, so basically just tried something quickly, and it appeared to work.

I think we need unit tests:
- what happens when minTempo is less than max? i think this will still "work" (i.e. it won't be an infinite loop) but might be unexpected
- if we merge this, we need to update the other web-audio-beat-detector* libs

Also: I wasn't sure whether to add 2 new arguments to each function (commit 78ef8e6cd60cc608279029e64c484a2c6989bbba):
minTempo, maxTempo
Or just keep 1 (commit 0aa3f11b5c5cc4fe07d768b8e978803335984066):
tempoSettings

I decided on only adding 1.
